### PR TITLE
@nekochans/lgtm-cat-ui を最新安定版に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "lgtm-cat-ui-test",
       "version": "1.0.0",
       "dependencies": {
-        "@nekochans/lgtm-cat-ui": "^0.15.1",
+        "@nekochans/lgtm-cat-ui": "^0.16.1",
         "next": "^12.2.3",
         "nookies": "^2.5.2",
         "react": "^18.2.0",
@@ -4101,9 +4101,9 @@
       "dev": true
     },
     "node_modules/@nekochans/lgtm-cat-ui": {
-      "version": "0.15.1",
-      "resolved": "https://npm.pkg.github.com/download/@nekochans/lgtm-cat-ui/0.15.1/5505a87e33b983f669154ff3c9c589cdaca68e95",
-      "integrity": "sha512-PqpfgmjGDuT4kz4g5AVC6kH2AT/iPULH5Dmu/vqwjCzZma3j/vUInWPh2D7D/vSwsNV6a2phZ4yVUg5dLqvRYg==",
+      "version": "0.16.1",
+      "resolved": "https://npm.pkg.github.com/download/@nekochans/lgtm-cat-ui/0.16.1/069a87b02d6312e0386e27c49883b6853f1c6d14",
+      "integrity": "sha512-B2OXOY0kRJnxay5VwTTpzg20EEh0enev9mw9tXpWe9YpY77SDEwe0AlpKnqUshG7eBgBuzSH+MAB+gf9QkDwCg==",
       "license": "MIT",
       "peerDependencies": {
         "next": "^12.2.3",
@@ -35724,9 +35724,9 @@
       }
     },
     "@nekochans/lgtm-cat-ui": {
-      "version": "0.15.1",
-      "resolved": "https://npm.pkg.github.com/download/@nekochans/lgtm-cat-ui/0.15.1/5505a87e33b983f669154ff3c9c589cdaca68e95",
-      "integrity": "sha512-PqpfgmjGDuT4kz4g5AVC6kH2AT/iPULH5Dmu/vqwjCzZma3j/vUInWPh2D7D/vSwsNV6a2phZ4yVUg5dLqvRYg==",
+      "version": "0.16.1",
+      "resolved": "https://npm.pkg.github.com/download/@nekochans/lgtm-cat-ui/0.16.1/069a87b02d6312e0386e27c49883b6853f1c6d14",
+      "integrity": "sha512-B2OXOY0kRJnxay5VwTTpzg20EEh0enev9mw9tXpWe9YpY77SDEwe0AlpKnqUshG7eBgBuzSH+MAB+gf9QkDwCg==",
       "requires": {}
     },
     "@next/env": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build-storybook": "build-storybook -s public"
   },
   "dependencies": {
-    "@nekochans/lgtm-cat-ui": "^0.15.1",
+    "@nekochans/lgtm-cat-ui": "^0.16.1",
     "next": "^12.2.3",
     "nookies": "^2.5.2",
     "react": "^18.2.0",

--- a/src/pages/privacy.tsx
+++ b/src/pages/privacy.tsx
@@ -3,10 +3,11 @@ import fs from 'fs';
 import { convertLocaleToLanguage } from '../features/locale';
 import { TermsOrPrivacyTemplate } from '../templates';
 
+import type { Language } from '@nekochans/lgtm-cat-ui';
 import type { GetStaticProps, NextPage } from 'next';
 
 type Props = {
-  language: 'ja' | 'en';
+  language: Language;
   privacyJa: string;
   privacyEn: string;
 };

--- a/src/pages/terms.tsx
+++ b/src/pages/terms.tsx
@@ -3,15 +3,16 @@ import fs from 'fs';
 import { convertLocaleToLanguage } from '../features/locale';
 import { TermsOrPrivacyTemplate } from '../templates';
 
+import type { Language } from '@nekochans/lgtm-cat-ui';
 import type { GetStaticProps, NextPage } from 'next';
 
 type Props = {
-  language: 'ja' | 'en';
+  language: Language;
   termsJa: string;
   termsEn: string;
 };
 
-const TermsPage: NextPage<Props> = ({ language, termsJa, termsEn }: Props) => (
+const TermsPage: NextPage<Props> = ({ language, termsJa, termsEn }) => (
   <TermsOrPrivacyTemplate
     type="terms"
     language={language}

--- a/src/templates/ErrorTemplate/ErrorTemplate.tsx
+++ b/src/templates/ErrorTemplate/ErrorTemplate.tsx
@@ -1,8 +1,10 @@
 import {
   ErrorTemplate as OrgErrorTemplate,
-  Language,
+  type Language,
+  ErrorType,
 } from '@nekochans/lgtm-cat-ui';
 
+import { httpStatusCode } from '../../constants/httpStatusCode';
 import {
   custom404title,
   customErrorTitle,
@@ -18,24 +20,18 @@ import { ServiceUnavailableImage } from './ServiceUnavailableImage';
 
 import type { FC } from 'react';
 
-// eslint-disable-next-line
-type ErrorType = 404 | 500 | 503;
-
 type Props = {
   type: ErrorType;
-  language: 'ja' | 'en';
+  language: Language;
 };
 
 const catImage = (type: ErrorType): JSX.Element => {
   switch (type) {
-    // eslint-disable-next-line no-magic-numbers
-    case 404:
+    case httpStatusCode.notFound:
       return <NotFoundImage />;
-    // eslint-disable-next-line no-magic-numbers
-    case 500:
+    case httpStatusCode.internalServerError:
       return <InternalServerErrorImage />;
-    // eslint-disable-next-line no-magic-numbers
-    case 503:
+    case httpStatusCode.serviceUnavailable:
       return <ServiceUnavailableImage />;
     default:
       return assertNever(type);
@@ -44,14 +40,11 @@ const catImage = (type: ErrorType): JSX.Element => {
 
 const pageTitle = (type: ErrorType, language: Language) => {
   switch (type) {
-    // eslint-disable-next-line no-magic-numbers
-    case 404:
+    case httpStatusCode.notFound:
       return custom404title(language);
-    // eslint-disable-next-line no-magic-numbers
-    case 500:
+    case httpStatusCode.internalServerError:
       return customErrorTitle(language);
-    // eslint-disable-next-line no-magic-numbers
-    case 503:
+    case httpStatusCode.serviceUnavailable:
       return metaTagList(language).maintenance.title;
     default:
       return assertNever(type);

--- a/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.tsx
+++ b/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.tsx
@@ -2,6 +2,7 @@ import {
   TermsOrPrivacyTemplate as OrgTermsOrPrivacyTemplate,
   useSwitchLanguage,
   type Language,
+  TemplateType,
 } from '@nekochans/lgtm-cat-ui';
 
 import { MarkdownContents } from '../../components';
@@ -12,7 +13,7 @@ import { DefaultLayout } from '../../layouts';
 import type { FC } from 'react';
 
 type Props = {
-  type: 'terms' | 'privacy';
+  type: TemplateType;
   language: Language;
   jaMarkdown: string;
   enMarkdown: string;

--- a/src/templates/TopTemplate/TopTemplate.tsx
+++ b/src/templates/TopTemplate/TopTemplate.tsx
@@ -3,12 +3,13 @@ import {
   type LgtmImage,
   Language,
 } from '@nekochans/lgtm-cat-ui';
-import { FC } from 'react';
 
 import { metaTagList } from '../../features/metaTag';
 import { appBaseUrl } from '../../features/url';
 import { useSaveSettingLanguage } from '../../hooks/useSaveSettingLanguage';
 import { DefaultLayout } from '../../layouts';
+
+import type { FC } from 'react';
 
 // eslint-disable-next-line max-lines-per-function, require-await
 const randomCatImagesFetcher = async () => {

--- a/src/templates/UploadTemplate/UploadTemplate.tsx
+++ b/src/templates/UploadTemplate/UploadTemplate.tsx
@@ -2,6 +2,7 @@
 import {
   UploadTemplate as OrgUploadTemplate,
   type Language,
+  AcceptedTypesImageExtension,
 } from '@nekochans/lgtm-cat-ui';
 import Image from 'next/image';
 
@@ -26,8 +27,6 @@ export const sleep = (
       resolve();
     }, waitSeconds * millisecond);
   });
-
-type AcceptedTypesImageExtension = '.png' | '.jpg' | '.jpeg';
 
 const imageValidator = async (
   image: string,


### PR DESCRIPTION
# issueURL
なし

#  内容

`@nekochans/lgtm-cat-ui` を最新安定版である `0.16.1` に変更。

`0.16.1` ではいくつかの型定義がexportされるようになったので `@nekochans/lgtm-cat-ui` の型定義を利用するように変更