### PR TITLE
言語の機能はfeaturesに移動

### DIFF
--- a/src/edge/language.ts
+++ b/src/edge/language.ts
@@ -1,8 +1,6 @@
 import { NextRequest } from 'next/server';
 
-import { isLanguage } from '../features/language';
-
-import type { Language } from '@nekochans/lgtm-cat-ui';
+import { isLanguage, type Language } from '../features/language';
 
 export const mightExtractLanguage = (
   req: NextRequest,

--- a/src/edge/language.ts
+++ b/src/edge/language.ts
@@ -1,16 +1,8 @@
 import { NextRequest } from 'next/server';
 
+import { isLanguage } from '../features/language';
+
 import type { Language } from '@nekochans/lgtm-cat-ui';
-
-const languages = ['en', 'ja'] as const;
-
-const isLanguage = (value: unknown): value is Language => {
-  if (typeof value !== 'string') {
-    return false;
-  }
-
-  return languages.includes(value as Language);
-};
 
 export const mightExtractLanguage = (
   req: NextRequest,

--- a/src/features/language.ts
+++ b/src/features/language.ts
@@ -1,4 +1,6 @@
-import { Language } from '@nekochans/lgtm-cat-ui';
+import { Language as OrgLanguage } from '@nekochans/lgtm-cat-ui';
+
+export type Language = OrgLanguage;
 
 export const languages = ['en', 'ja'] as const;
 

--- a/src/features/language.ts
+++ b/src/features/language.ts
@@ -1,0 +1,11 @@
+import { Language } from '@nekochans/lgtm-cat-ui';
+
+export const languages = ['en', 'ja'] as const;
+
+export const isLanguage = (value: unknown): value is Language => {
+  if (typeof value !== 'string') {
+    return false;
+  }
+
+  return languages.includes(value as Language);
+};

--- a/src/features/locale.ts
+++ b/src/features/locale.ts
@@ -1,6 +1,6 @@
 import { assertNever } from '../utils/assertNever';
 
-import type { Language } from '@nekochans/lgtm-cat-ui';
+import type { Language } from './language';
 
 const locales = ['jp-JP', 'en-US'] as const;
 

--- a/src/features/metaTag.ts
+++ b/src/features/metaTag.ts
@@ -2,7 +2,7 @@ import { assertNever } from '../utils/assertNever';
 
 import { appUrlList, type AppPathName, AppUrl } from './url';
 
-import type { Language } from '@nekochans/lgtm-cat-ui';
+import type { Language } from './language';
 
 type AppName = 'LGTMeow';
 

--- a/src/hooks/useSaveSettingLanguage.ts
+++ b/src/hooks/useSaveSettingLanguage.ts
@@ -1,6 +1,6 @@
 import { setCookie } from '../utils/cookie';
 
-import type { Language } from '@nekochans/lgtm-cat-ui';
+import type { Language } from '../features/language';
 
 const saveSettingLanguage = (language: Language) => {
   // 有効祈願は約1年間に設定する

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,9 +1,9 @@
-import { Language } from '@nekochans/lgtm-cat-ui';
-import { GetStaticProps, NextPage } from 'next';
-
 import { httpStatusCode } from '../constants/httpStatusCode';
 import { convertLocaleToLanguage } from '../features/locale';
 import { ErrorTemplate } from '../templates';
+
+import type { Language } from '../features/language';
+import type { GetStaticProps, NextPage } from 'next';
 
 type Props = {
   language: Language;

--- a/src/pages/_error.tsx
+++ b/src/pages/_error.tsx
@@ -7,7 +7,7 @@ import {
 import { convertLocaleToLanguage } from '../features/locale';
 import { ErrorTemplate } from '../templates';
 
-import type { Language } from '@nekochans/lgtm-cat-ui';
+import type { Language } from '../features/language';
 import type { NextPage, NextPageContext } from 'next';
 
 type Props = {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,7 +3,8 @@ import { TopTemplate } from '../templates';
 import { imageData } from '../utils/imageData';
 import { extractRandomImages } from '../utils/randomImages';
 
-import type { Language, LgtmImage } from '@nekochans/lgtm-cat-ui';
+import type { Language } from '../features/language';
+import type { LgtmImage } from '@nekochans/lgtm-cat-ui';
 import type { GetStaticProps, NextPage } from 'next';
 
 type Props = {

--- a/src/pages/maintenance.tsx
+++ b/src/pages/maintenance.tsx
@@ -2,7 +2,7 @@ import { httpStatusCode } from '../constants/httpStatusCode';
 import { convertLocaleToLanguage } from '../features/locale';
 import { ErrorTemplate } from '../templates';
 
-import type { Language } from '@nekochans/lgtm-cat-ui';
+import type { Language } from '../features/language';
 import type { GetStaticProps, NextPage } from 'next';
 
 type Props = {

--- a/src/pages/privacy.tsx
+++ b/src/pages/privacy.tsx
@@ -3,7 +3,7 @@ import fs from 'fs';
 import { convertLocaleToLanguage } from '../features/locale';
 import { TermsOrPrivacyTemplate } from '../templates';
 
-import type { Language } from '@nekochans/lgtm-cat-ui';
+import type { Language } from '../features/language';
 import type { GetStaticProps, NextPage } from 'next';
 
 type Props = {

--- a/src/pages/terms.tsx
+++ b/src/pages/terms.tsx
@@ -3,7 +3,7 @@ import fs from 'fs';
 import { convertLocaleToLanguage } from '../features/locale';
 import { TermsOrPrivacyTemplate } from '../templates';
 
-import type { Language } from '@nekochans/lgtm-cat-ui';
+import type { Language } from '../features/language';
 import type { GetStaticProps, NextPage } from 'next';
 
 type Props = {

--- a/src/pages/upload.tsx
+++ b/src/pages/upload.tsx
@@ -1,7 +1,7 @@
 import { convertLocaleToLanguage } from '../features/locale';
 import { UploadTemplate } from '../templates';
 
-import type { Language } from '@nekochans/lgtm-cat-ui';
+import type { Language } from '../features/language';
 import type { GetStaticProps, NextPage } from 'next';
 
 type Props = {

--- a/src/templates/ErrorTemplate/ErrorTemplate.tsx
+++ b/src/templates/ErrorTemplate/ErrorTemplate.tsx
@@ -1,7 +1,6 @@
 import {
   ErrorTemplate as OrgErrorTemplate,
-  type Language,
-  ErrorType,
+  type ErrorType,
 } from '@nekochans/lgtm-cat-ui';
 
 import { httpStatusCode } from '../../constants/httpStatusCode';
@@ -18,6 +17,7 @@ import { InternalServerErrorImage } from './InternalServerErrorImage';
 import { NotFoundImage } from './NotFoundImage';
 import { ServiceUnavailableImage } from './ServiceUnavailableImage';
 
+import type { Language } from '../../features/language';
 import type { FC } from 'react';
 
 type Props = {

--- a/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.tsx
+++ b/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.tsx
@@ -1,8 +1,7 @@
 import {
   TermsOrPrivacyTemplate as OrgTermsOrPrivacyTemplate,
   useSwitchLanguage,
-  type Language,
-  TemplateType,
+  type TemplateType,
 } from '@nekochans/lgtm-cat-ui';
 
 import { MarkdownContents } from '../../components';
@@ -10,6 +9,7 @@ import { metaTagList } from '../../features/metaTag';
 import { useSaveSettingLanguage } from '../../hooks/useSaveSettingLanguage';
 import { DefaultLayout } from '../../layouts';
 
+import type { Language } from '../../features/language';
 import type { FC } from 'react';
 
 type Props = {

--- a/src/templates/TopTemplate/TopTemplate.tsx
+++ b/src/templates/TopTemplate/TopTemplate.tsx
@@ -1,7 +1,6 @@
 import {
   TopTemplate as OrgTopTemplate,
   type LgtmImage,
-  Language,
 } from '@nekochans/lgtm-cat-ui';
 
 import { metaTagList } from '../../features/metaTag';
@@ -9,6 +8,7 @@ import { appBaseUrl } from '../../features/url';
 import { useSaveSettingLanguage } from '../../hooks/useSaveSettingLanguage';
 import { DefaultLayout } from '../../layouts';
 
+import type { Language } from '../../features/language';
 import type { FC } from 'react';
 
 // eslint-disable-next-line max-lines-per-function, require-await

--- a/src/templates/UploadTemplate/UploadTemplate.tsx
+++ b/src/templates/UploadTemplate/UploadTemplate.tsx
@@ -2,8 +2,7 @@
 import {
   UploadTemplate as OrgUploadTemplate,
   createSuccessResult,
-  type Language,
-  AcceptedTypesImageExtension,
+  type AcceptedTypesImageExtension,
 } from '@nekochans/lgtm-cat-ui';
 import Image from 'next/image';
 
@@ -13,6 +12,7 @@ import { DefaultLayout } from '../../layouts';
 
 import cat from './images/cat.webp';
 
+import type { Language } from '../../features/language';
 import type { FC } from 'react';
 
 const millisecond = 1000;


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/lgtm-cat-ui-test/issues/21

# 内容

`isLanguage` などの言語に関する機能はfeaturesに移動。

`@nekochans/lgtm-cat-ui` に定義されている型定義 `Language` が多くの場所で利用されていたが、万が一修正が入った際の影響範囲が大きいので言語の型定義もfeaturesに定義するように変更。
