### PR TITLE
@nekochans/lgtm-cat-ui は templates, features 以外からはimportしないように変更

### DIFF
--- a/src/features/lgtmImage.ts
+++ b/src/features/lgtmImage.ts
@@ -1,0 +1,3 @@
+import type { LgtmImage as OrgLgtmImage } from '@nekochans/lgtm-cat-ui';
+
+export type LgtmImage = OrgLgtmImage;

--- a/src/features/lgtmImage.ts
+++ b/src/features/lgtmImage.ts
@@ -1,3 +1,8 @@
-import type { LgtmImage as OrgLgtmImage } from '@nekochans/lgtm-cat-ui';
+import type {
+  LgtmImage as OrgLgtmImage,
+  AcceptedTypesImageExtension as OrgAcceptedTypesImageExtension,
+} from '@nekochans/lgtm-cat-ui';
 
 export type LgtmImage = OrgLgtmImage;
+
+export type AcceptedTypesImageExtension = OrgAcceptedTypesImageExtension;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,7 +4,7 @@ import { imageData } from '../utils/imageData';
 import { extractRandomImages } from '../utils/randomImages';
 
 import type { Language } from '../features/language';
-import type { LgtmImage } from '@nekochans/lgtm-cat-ui';
+import type { LgtmImage } from '../features/lgtmImage';
 import type { GetStaticProps, NextPage } from 'next';
 
 type Props = {

--- a/src/templates/UploadTemplate/UploadTemplate.tsx
+++ b/src/templates/UploadTemplate/UploadTemplate.tsx
@@ -2,7 +2,6 @@
 import {
   UploadTemplate as OrgUploadTemplate,
   createSuccessResult,
-  type AcceptedTypesImageExtension,
 } from '@nekochans/lgtm-cat-ui';
 import Image from 'next/image';
 
@@ -13,6 +12,7 @@ import { DefaultLayout } from '../../layouts';
 import cat from './images/cat.webp';
 
 import type { Language } from '../../features/language';
+import type { AcceptedTypesImageExtension } from '../../features/lgtmImage';
 import type { FC } from 'react';
 
 const millisecond = 1000;

--- a/src/utils/imageData.ts
+++ b/src/utils/imageData.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines */
-import { LgtmImage } from '@nekochans/lgtm-cat-ui';
+import { LgtmImage } from '../features/lgtmImage';
 
 export const imageData: LgtmImage[] = [
   {

--- a/src/utils/randomImages.ts
+++ b/src/utils/randomImages.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-magic-numbers, id-length */
-import { LgtmImage } from '@nekochans/lgtm-cat-ui';
+import { LgtmImage } from '../features/lgtmImage';
 
 export const extractRandomImages = (
   arr: LgtmImage[],


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/lgtm-cat-ui-test/issues/33

# 内容

`@nekochans/lgtm-cat-ui` のexportする箇所を限定可する為に templates, features 以外からはimportしないように変更。

複数箇所で利用される、Result型、LgtmImage、AcceptedTypesImageExtensionをfeaturesに移動。