### PR TITLE
New arrival Cats 押下時に新しいねこ画像を取得する関数を実装

### DIFF
--- a/src/api/fetch/lgtmImage.ts
+++ b/src/api/fetch/lgtmImage.ts
@@ -1,6 +1,15 @@
 import { FetchLgtmImagesError } from '../../features/errors/FetchLgtmImagesError';
-import { FetchLgtmImages, isLgtmImages } from '../../features/lgtmImage';
-import { fetchLgtmImagesUrl } from '../../features/url';
+import {
+  isLgtmImages,
+  type FetchLgtmImages,
+  FetchLgtmImagesDto,
+  LgtmImage,
+} from '../../features/lgtmImage';
+import {
+  fetchLgtmImagesUrl,
+  fetchLgtmImagesInRecentlyCreatedUrl,
+  type Url,
+} from '../../features/url';
 
 type FetchImageResponseBody = {
   lgtmImages: {
@@ -40,7 +49,10 @@ const isFetchImageResponseBody = (
   return false;
 };
 
-export const fetchLgtmImagesInRandom: FetchLgtmImages = async (dto) => {
+const fetchLgtmImages = async (
+  dto: FetchLgtmImagesDto,
+  fetchUrl: Url,
+): Promise<LgtmImage[]> => {
   const options: RequestInit = {
     method: 'GET',
     mode: 'cors',
@@ -50,7 +62,7 @@ export const fetchLgtmImagesInRandom: FetchLgtmImages = async (dto) => {
     },
   };
 
-  const response = await fetch(fetchLgtmImagesUrl(), options);
+  const response = await fetch(fetchUrl, options);
   if (!response.ok) {
     throw new FetchLgtmImagesError(response.statusText);
   }
@@ -67,5 +79,13 @@ export const fetchLgtmImagesInRandom: FetchLgtmImages = async (dto) => {
     }
   }
 
-  throw new FetchLgtmImagesError();
+  throw new FetchLgtmImagesError('ResponseBody is not expected');
 };
+
+// eslint-disable-next-line require-await
+export const fetchLgtmImagesInRandom: FetchLgtmImages = async (dto) =>
+  fetchLgtmImages(dto, fetchLgtmImagesUrl());
+
+// eslint-disable-next-line require-await
+export const fetchLgtmImagesInRecentlyCreated: FetchLgtmImages = async (dto) =>
+  fetchLgtmImages(dto, fetchLgtmImagesInRecentlyCreatedUrl());

--- a/src/features/url.ts
+++ b/src/features/url.ts
@@ -1,4 +1,4 @@
-type Url = `http://localhost${string}` | `https://${string}`;
+export type Url = `http://localhost${string}` | `https://${string}`;
 
 const isUrl = (value: unknown): value is Url => {
   if (typeof value !== 'string') {

--- a/src/hooks/__tests__/useCatImagesFetcher/newArrivalCatImagesFetcher.spec.ts
+++ b/src/hooks/__tests__/useCatImagesFetcher/newArrivalCatImagesFetcher.spec.ts
@@ -1,0 +1,81 @@
+/**
+ * @jest-environment jsdom
+ */
+import 'whatwg-fetch';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+
+import { FetchLgtmImagesError } from '../../../features/errors/FetchLgtmImagesError';
+import {
+  apiList,
+  appBaseUrl,
+  fetchLgtmImagesInRecentlyCreatedUrl,
+} from '../../../features/url';
+import { mockInternalServerError } from '../../../mocks/api/error/mockInternalServerError';
+import { mockTokenEndpoint } from '../../../mocks/api/external/cognito/mockTokenEndpoint';
+import { mockFetchLgtmImages } from '../../../mocks/api/external/lgtmeow/mockFetchLgtmImages';
+import { fetchLgtmImagesMockBody } from '../../../mocks/api/fetchLgtmImagesMockBody';
+import { useCatImagesFetcher } from '../../useCatImagesFetcher';
+
+const mockHandlers = [
+  rest.post(
+    `${appBaseUrl()}${apiList.issueClientCredentialsAccessToken}`,
+    mockTokenEndpoint,
+  ),
+  rest.get(fetchLgtmImagesInRecentlyCreatedUrl(), mockFetchLgtmImages),
+];
+
+const mockServer = setupServer(...mockHandlers);
+
+// eslint-disable-next-line max-lines-per-function
+describe('useCatImagesFetcher.ts newArrivalCatImagesFetcher TestCases', () => {
+  beforeAll(() => {
+    mockServer.listen();
+  });
+
+  afterEach(() => {
+    mockServer.resetHandlers();
+  });
+
+  afterAll(() => {
+    mockServer.close();
+  });
+
+  it('should be able to fetch LGTM Images', async () => {
+    const expected = fetchLgtmImagesMockBody.lgtmImages.map((value) => ({
+      id: value.id,
+      imageUrl: value.url,
+    }));
+
+    const lgtmImages = await useCatImagesFetcher().newArrivalCatImagesFetcher();
+
+    expect(lgtmImages).toStrictEqual(expected);
+  });
+
+  it('should return an FetchLgtmImagesError because accessToken issuance failed', async () => {
+    mockServer.use(
+      rest.post(
+        `${appBaseUrl()}${apiList.issueClientCredentialsAccessToken}`,
+        mockInternalServerError,
+      ),
+    );
+
+    await expect(
+      useCatImagesFetcher().newArrivalCatImagesFetcher(),
+    ).rejects.toStrictEqual(new FetchLgtmImagesError('Internal Server Error'));
+  });
+
+  it('should throw a FetchLgtmImagesError because Failed to fetch LGTM Images', async () => {
+    mockServer.use(
+      rest.post(
+        `${appBaseUrl()}${apiList.issueClientCredentialsAccessToken}`,
+        mockTokenEndpoint,
+      ),
+      rest.get(fetchLgtmImagesInRecentlyCreatedUrl(), mockInternalServerError),
+    );
+
+    await expect(
+      useCatImagesFetcher().newArrivalCatImagesFetcher(),
+    ).rejects.toStrictEqual(new FetchLgtmImagesError('Internal Server Error'));
+  });
+});

--- a/src/hooks/useCatImagesFetcher.ts
+++ b/src/hooks/useCatImagesFetcher.ts
@@ -1,5 +1,8 @@
 import { issueAccessToken } from '../api/fetch/authToken';
-import { fetchLgtmImagesInRandom } from '../api/fetch/lgtmImage';
+import {
+  fetchLgtmImagesInRandom,
+  fetchLgtmImagesInRecentlyCreated,
+} from '../api/fetch/lgtmImage';
 
 import type { LgtmImage } from '../features/lgtmImage';
 
@@ -9,4 +12,13 @@ const randomCatImagesFetcher = async (): Promise<LgtmImage[]> => {
   return fetchLgtmImagesInRandom({ accessToken });
 };
 
-export const useCatImagesFetcher = () => ({ randomCatImagesFetcher });
+const newArrivalCatImagesFetcher = async (): Promise<LgtmImage[]> => {
+  const accessToken = await issueAccessToken();
+
+  return fetchLgtmImagesInRecentlyCreated({ accessToken });
+};
+
+export const useCatImagesFetcher = () => ({
+  randomCatImagesFetcher,
+  newArrivalCatImagesFetcher,
+});

--- a/src/templates/TopTemplate/TopTemplate.tsx
+++ b/src/templates/TopTemplate/TopTemplate.tsx
@@ -12,61 +12,6 @@ import { DefaultLayout } from '../../layouts';
 import type { Language } from '../../features/language';
 import type { FC } from 'react';
 
-// eslint-disable-next-line max-lines-per-function, require-await
-const newArrivalCatImagesFetcher = async () => {
-  const lgtmImagesList: LgtmImage[] = [
-    {
-      id: 21,
-      imageUrl:
-        'https://lgtm-images.lgtmeow.com/2022/07/26/13/2071d87f-3950-4ec3-94eb-3d116451329e.webp',
-    } as const,
-    {
-      id: 22,
-      imageUrl:
-        'https://lgtm-images.lgtmeow.com/2022/07/24/18/18f8abdb-c4c5-44f7-82ca-e7550eda0780.webp',
-    } as const,
-    {
-      id: 23,
-      imageUrl:
-        'https://lgtm-images.lgtmeow.com/2022/07/01/08/2141b748-d1ba-4d15-a9de-04d9f36e5518.webp',
-    } as const,
-    {
-      id: 24,
-      imageUrl:
-        'https://lgtm-images.lgtmeow.com/2022/06/30/14/041e978e-787c-4b45-a0a9-55702b4f2875.webp',
-    } as const,
-    {
-      id: 25,
-      imageUrl:
-        'https://lgtm-images.lgtmeow.com/2022/06/30/14/e1d0518c-00c5-4bb0-b5ad-fce05012c8d1.webp',
-    } as const,
-    {
-      id: 26,
-      imageUrl:
-        'https://lgtm-images.lgtmeow.com/2022/06/23/02/4f2f6098-6167-4a99-8026-fbeafcea3012.webp',
-    } as const,
-    {
-      id: 27,
-      imageUrl:
-        'https://lgtm-images.lgtmeow.com/2022/06/23/02/7052fd12-4007-45a7-9932-18d645397605.webp',
-    } as const,
-    {
-      id: 28,
-      imageUrl:
-        'https://lgtm-images.lgtmeow.com/2022/06/23/02/ffbadd8d-8d9d-4eae-9bd3-af11b330d8d6.webp',
-    } as const,
-    {
-      id: 29,
-      imageUrl:
-        'https://lgtm-images.lgtmeow.com/2022/02/24/22/ed78dd80-9bfc-456c-a474-917e5c311633.webp',
-    } as const,
-  ];
-
-  return lgtmImagesList;
-};
-
-const appUrl = appBaseUrl();
-
 const clipboardMarkdownCallback = () =>
   // eslint-disable-next-line no-console
   console.log('clipboardMarkdownCallback executed!');
@@ -89,7 +34,8 @@ export const TopTemplate: FC<Props> = ({ language, lgtmImages }) => {
 
   const { saveSettingLanguage } = useSaveSettingLanguage();
 
-  const { randomCatImagesFetcher } = useCatImagesFetcher();
+  const { randomCatImagesFetcher, newArrivalCatImagesFetcher } =
+    useCatImagesFetcher();
 
   return (
     <DefaultLayout metaTag={metaTag}>
@@ -98,7 +44,7 @@ export const TopTemplate: FC<Props> = ({ language, lgtmImages }) => {
         lgtmImages={lgtmImages}
         randomCatImagesFetcher={randomCatImagesFetcher}
         newArrivalCatImagesFetcher={newArrivalCatImagesFetcher}
-        appUrl={appUrl}
+        appUrl={appBaseUrl()}
         fetchRandomCatImagesCallback={fetchRandomCatImagesCallback}
         fetchNewArrivalCatImagesCallback={fetchNewArrivalCatImagesCallback}
         clipboardMarkdownCallback={clipboardMarkdownCallback}


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/lgtm-cat-ui-test/issues/25

# 内容

New arrival Cats 押下時に新しいねこ画像を取得する関数を実装。

https://github.com/keitakn/lgtm-cat-ui-test/pull/42 で実装した関数と内容的にはほとんど同じなので共通処理を切り出すリファクタリングを実施している。
