### PR TITLE
画像アップロード時にねこ画像判定APIに通信する関数を実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "lgtm-cat-ui-test",
       "version": "1.0.0",
       "dependencies": {
-        "@nekochans/lgtm-cat-ui": "^0.16.1",
+        "@nekochans/lgtm-cat-ui": "^0.16.2",
         "next": "^12.2.3",
         "nookies": "^2.5.2",
         "react": "^18.2.0",
@@ -4136,9 +4136,9 @@
       }
     },
     "node_modules/@nekochans/lgtm-cat-ui": {
-      "version": "0.16.1",
-      "resolved": "https://npm.pkg.github.com/download/@nekochans/lgtm-cat-ui/0.16.1/069a87b02d6312e0386e27c49883b6853f1c6d14",
-      "integrity": "sha512-B2OXOY0kRJnxay5VwTTpzg20EEh0enev9mw9tXpWe9YpY77SDEwe0AlpKnqUshG7eBgBuzSH+MAB+gf9QkDwCg==",
+      "version": "0.16.2",
+      "resolved": "https://npm.pkg.github.com/download/@nekochans/lgtm-cat-ui/0.16.2/0292861fdc09ef4e5c1998a52bedc75a30a8a48d",
+      "integrity": "sha512-wW7zWvfVaScO46aQFvCWFuqxSXSUQNaTGI7YwDGQhB5vpfLtIzoEXDOCZSU2zlORrXAJ3RRJYWmliftx5Y3UZg==",
       "license": "MIT",
       "peerDependencies": {
         "next": "^12.2.3",
@@ -36621,9 +36621,9 @@
       }
     },
     "@nekochans/lgtm-cat-ui": {
-      "version": "0.16.1",
-      "resolved": "https://npm.pkg.github.com/download/@nekochans/lgtm-cat-ui/0.16.1/069a87b02d6312e0386e27c49883b6853f1c6d14",
-      "integrity": "sha512-B2OXOY0kRJnxay5VwTTpzg20EEh0enev9mw9tXpWe9YpY77SDEwe0AlpKnqUshG7eBgBuzSH+MAB+gf9QkDwCg==",
+      "version": "0.16.2",
+      "resolved": "https://npm.pkg.github.com/download/@nekochans/lgtm-cat-ui/0.16.2/0292861fdc09ef4e5c1998a52bedc75a30a8a48d",
+      "integrity": "sha512-wW7zWvfVaScO46aQFvCWFuqxSXSUQNaTGI7YwDGQhB5vpfLtIzoEXDOCZSU2zlORrXAJ3RRJYWmliftx5Y3UZg==",
       "requires": {}
     },
     "@next/env": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build-storybook": "build-storybook -s public"
   },
   "dependencies": {
-    "@nekochans/lgtm-cat-ui": "^0.16.1",
+    "@nekochans/lgtm-cat-ui": "^0.16.2",
     "next": "^12.2.3",
     "nookies": "^2.5.2",
     "react": "^18.2.0",

--- a/src/features/errors/IsAcceptableCatImageError.ts
+++ b/src/features/errors/IsAcceptableCatImageError.ts
@@ -1,0 +1,10 @@
+export class IsAcceptableCatImageError extends Error {
+  constructor(error?: string) {
+    super(error);
+    this.name = new.target.name;
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
+  }
+}

--- a/src/features/errors/UploadCatImageSizeTooLargeError.ts
+++ b/src/features/errors/UploadCatImageSizeTooLargeError.ts
@@ -1,0 +1,10 @@
+export class UploadCatImageSizeTooLargeError extends Error {
+  constructor(error?: string) {
+    super(error);
+    this.name = new.target.name;
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
+  }
+}

--- a/src/features/lgtmImage.ts
+++ b/src/features/lgtmImage.ts
@@ -1,4 +1,7 @@
+import { UploadCatImageSizeTooLargeError } from './errors/UploadCatImageSizeTooLargeError';
+
 import type { AccessToken } from './authToken';
+import type { Result } from './result';
 import type {
   LgtmImage as OrgLgtmImage,
   AcceptedTypesImageExtension as OrgAcceptedTypesImageExtension,
@@ -13,6 +16,30 @@ export type FetchLgtmImagesDto = {
 };
 
 export type FetchLgtmImages = (dto: FetchLgtmImagesDto) => Promise<LgtmImage[]>;
+
+export type IsAcceptableCatImageDto = {
+  accessToken: AccessToken;
+  image: string;
+  imageExtension: AcceptedTypesImageExtension;
+};
+
+export type IsAcceptableCatImageNotAcceptableReason =
+  | 'not an allowed image extension'
+  | 'not moderation image'
+  | 'person face in the image'
+  | 'not cat image'
+  | 'an error has occurred';
+
+export type IsAcceptableCatImageResponse = {
+  isAcceptableCatImage: boolean;
+  notAcceptableReason: IsAcceptableCatImageNotAcceptableReason;
+};
+
+export type IsAcceptableCatImage = (
+  dto: IsAcceptableCatImageDto,
+) => Promise<
+  Result<IsAcceptableCatImageResponse, UploadCatImageSizeTooLargeError>
+>;
 
 export const isLgtmImages = (value: unknown): value is LgtmImage[] => {
   if (Array.isArray(value)) {

--- a/src/hooks/__tests__/useCatImageValidator.spec.ts
+++ b/src/hooks/__tests__/useCatImageValidator.spec.ts
@@ -1,0 +1,268 @@
+/**
+ * @jest-environment jsdom
+ */
+import 'whatwg-fetch';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+
+import { IsAcceptableCatImageError } from '../../features/errors/IsAcceptableCatImageError';
+import { IssueAccessTokenError } from '../../features/errors/IssueAccessTokenError';
+import { isSuccessResult } from '../../features/result';
+import {
+  apiList,
+  appBaseUrl,
+  isAcceptableCatImageUrl,
+} from '../../features/url';
+import { mockInternalServerError } from '../../mocks/api/error/mockInternalServerError';
+import { mockTokenEndpoint } from '../../mocks/api/external/cognito/mockTokenEndpoint';
+import { mockIsAcceptableCatImage } from '../../mocks/api/external/recognition/mockIsAcceptableCatImage';
+import { mockIsAcceptableCatImageError } from '../../mocks/api/external/recognition/mockIsAcceptableCatImageError';
+import { mockIsAcceptableCatImageNotAllowedImageExtension } from '../../mocks/api/external/recognition/mockIsAcceptableCatImageNotAllowedImageExtension';
+import { mockIsAcceptableCatImageNotCatImage } from '../../mocks/api/external/recognition/mockIsAcceptableCatImageNotCatImage';
+import { mockIsAcceptableCatImageNotModerationImage } from '../../mocks/api/external/recognition/mockIsAcceptableCatImageNotModerationImage';
+import { mockIsAcceptableCatImagePersonFaceInImage } from '../../mocks/api/external/recognition/mockIsAcceptableCatImagePersonFaceInImage';
+import { useCatImageValidator } from '../useCatImageValidator';
+
+const mockHandlers = [
+  rest.post(
+    `${appBaseUrl()}${apiList.issueClientCredentialsAccessToken}`,
+    mockTokenEndpoint,
+  ),
+  rest.post(isAcceptableCatImageUrl(), mockIsAcceptableCatImage),
+];
+
+const mockServer = setupServer(...mockHandlers);
+
+// eslint-disable-next-line max-lines-per-function, max-statements
+describe('useCatImageValidator isAcceptableCatImage TestCases', () => {
+  beforeAll(() => {
+    mockServer.listen();
+  });
+
+  afterEach(() => {
+    mockServer.resetHandlers();
+  });
+
+  afterAll(() => {
+    mockServer.close();
+  });
+
+  const langJa = 'ja';
+
+  const langEn = 'en';
+
+  const dummyImage = 'dummy image';
+
+  const dummyImageExtension = '.jpg';
+
+  it.each`
+    language  | image         | imageExtension         | expected
+    ${langJa} | ${dummyImage} | ${dummyImageExtension} | ${{ isAcceptableCatImage: true, notAcceptableReason: [] }}
+    ${langEn} | ${dummyImage} | ${dummyImageExtension} | ${{ isAcceptableCatImage: true, notAcceptableReason: [] }}
+  `(
+    'should be true for isAcceptableCatImage. language: $language',
+    async ({ language, image, imageExtension, expected }) => {
+      const { imageValidator } = useCatImageValidator(language);
+
+      const isAcceptableCatImageResult = await imageValidator(
+        image,
+        imageExtension,
+      );
+
+      expect(isSuccessResult(isAcceptableCatImageResult)).toBeTruthy();
+      expect(isAcceptableCatImageResult.value).toStrictEqual(expected);
+    },
+  );
+
+  it.each`
+    language  | image         | imageExtension         | expected
+    ${langJa} | ${dummyImage} | ${dummyImageExtension} | ${{ isAcceptableCatImage: false, notAcceptableReason: ['png, jpg, jpeg の画像のみアップロード出来ます。'] }}
+    ${langEn} | ${dummyImage} | ${dummyImageExtension} | ${{ isAcceptableCatImage: false, notAcceptableReason: ['Sorry, only png, jpg, jpeg images can be uploaded.'] }}
+  `(
+    'should result in isAcceptableCatImage being false because not an allowed image extension. language: $language',
+    async ({ language, image, imageExtension, expected }) => {
+      const { imageValidator } = useCatImageValidator(language);
+
+      mockServer.use(
+        rest.post(
+          `${appBaseUrl()}${apiList.issueClientCredentialsAccessToken}`,
+          mockTokenEndpoint,
+        ),
+        rest.post(
+          isAcceptableCatImageUrl(),
+          mockIsAcceptableCatImageNotAllowedImageExtension,
+        ),
+      );
+
+      const isAcceptableCatImageResult = await imageValidator(
+        image,
+        imageExtension,
+      );
+
+      expect(isSuccessResult(isAcceptableCatImageResult)).toBeTruthy();
+      expect(isAcceptableCatImageResult.value).toStrictEqual(expected);
+    },
+  );
+
+  it.each`
+    language  | image         | imageExtension         | expected
+    ${langJa} | ${dummyImage} | ${dummyImageExtension} | ${{ isAcceptableCatImage: false, notAcceptableReason: ['この画像は不適切なものが写っているので利用出来ません。'] }}
+    ${langEn} | ${dummyImage} | ${dummyImageExtension} | ${{ isAcceptableCatImage: false, notAcceptableReason: ['Sorry, This image is not available because it shows something inappropriate.'] }}
+  `(
+    'should result in isAcceptableCatImage being false because not moderation image. language: $language',
+    async ({ language, image, imageExtension, expected }) => {
+      const { imageValidator } = useCatImageValidator(language);
+
+      mockServer.use(
+        rest.post(
+          `${appBaseUrl()}${apiList.issueClientCredentialsAccessToken}`,
+          mockTokenEndpoint,
+        ),
+        rest.post(
+          isAcceptableCatImageUrl(),
+          mockIsAcceptableCatImageNotModerationImage,
+        ),
+      );
+
+      const isAcceptableCatImageResult = await imageValidator(
+        image,
+        imageExtension,
+      );
+
+      expect(isSuccessResult(isAcceptableCatImageResult)).toBeTruthy();
+      expect(isAcceptableCatImageResult.value).toStrictEqual(expected);
+    },
+  );
+
+  it.each`
+    language  | image         | imageExtension         | expected
+    ${langJa} | ${dummyImage} | ${dummyImageExtension} | ${{ isAcceptableCatImage: false, notAcceptableReason: ['申し訳ありませんが人の顔が写っていない画像をご利用ください。'] }}
+    ${langEn} | ${dummyImage} | ${dummyImageExtension} | ${{ isAcceptableCatImage: false, notAcceptableReason: ["Sorry, please use images that do not show people's faces."] }}
+  `(
+    'should result in isAcceptableCatImage being false because person face in the image. language: $language',
+    async ({ language, image, imageExtension, expected }) => {
+      const { imageValidator } = useCatImageValidator(language);
+
+      mockServer.use(
+        rest.post(
+          `${appBaseUrl()}${apiList.issueClientCredentialsAccessToken}`,
+          mockTokenEndpoint,
+        ),
+        rest.post(
+          isAcceptableCatImageUrl(),
+          mockIsAcceptableCatImagePersonFaceInImage,
+        ),
+      );
+
+      const isAcceptableCatImageResult = await imageValidator(
+        image,
+        imageExtension,
+      );
+
+      expect(isSuccessResult(isAcceptableCatImageResult)).toBeTruthy();
+      expect(isAcceptableCatImageResult.value).toStrictEqual(expected);
+    },
+  );
+
+  it.each`
+    language  | image         | imageExtension         | expected
+    ${langJa} | ${dummyImage} | ${dummyImageExtension} | ${{ isAcceptableCatImage: false, notAcceptableReason: ['申し訳ありませんがはっきりと猫が写っている画像をご利用ください。'] }}
+    ${langEn} | ${dummyImage} | ${dummyImageExtension} | ${{ isAcceptableCatImage: false, notAcceptableReason: ['Sorry, but please use images that clearly show the cat.'] }}
+  `(
+    'should result in isAcceptableCatImage being false because not cat image. language: $language',
+    async ({ language, image, imageExtension, expected }) => {
+      const { imageValidator } = useCatImageValidator(language);
+
+      mockServer.use(
+        rest.post(
+          `${appBaseUrl()}${apiList.issueClientCredentialsAccessToken}`,
+          mockTokenEndpoint,
+        ),
+        rest.post(
+          isAcceptableCatImageUrl(),
+          mockIsAcceptableCatImageNotCatImage,
+        ),
+      );
+
+      const isAcceptableCatImageResult = await imageValidator(
+        image,
+        imageExtension,
+      );
+
+      expect(isSuccessResult(isAcceptableCatImageResult)).toBeTruthy();
+      expect(isAcceptableCatImageResult.value).toStrictEqual(expected);
+    },
+  );
+
+  it.each`
+    language  | image         | imageExtension         | expected
+    ${langJa} | ${dummyImage} | ${dummyImageExtension} | ${{ isAcceptableCatImage: false, notAcceptableReason: ['予期せぬエラーが発生しました。', 'お手数ですが、しばらく時間が経ってからお試し下さい。'] }}
+    ${langEn} | ${dummyImage} | ${dummyImageExtension} | ${{ isAcceptableCatImage: false, notAcceptableReason: ['An unexpected Error occurred.', 'Sorry, please try again after some time has passed.'] }}
+  `(
+    'should result in isAcceptableCatImage being false because an error has occurred. language: $language',
+    async ({ language, image, imageExtension, expected }) => {
+      const { imageValidator } = useCatImageValidator(language);
+
+      mockServer.use(
+        rest.post(
+          `${appBaseUrl()}${apiList.issueClientCredentialsAccessToken}`,
+          mockTokenEndpoint,
+        ),
+        rest.post(isAcceptableCatImageUrl(), mockIsAcceptableCatImageError),
+      );
+
+      const isAcceptableCatImageResult = await imageValidator(
+        image,
+        imageExtension,
+      );
+
+      expect(isSuccessResult(isAcceptableCatImageResult)).toBeTruthy();
+      expect(isAcceptableCatImageResult.value).toStrictEqual(expected);
+    },
+  );
+
+  it.each`
+    language  | image         | imageExtension         | expected
+    ${langJa} | ${dummyImage} | ${dummyImageExtension} | ${new IsAcceptableCatImageError('Internal Server Error')}
+    ${langEn} | ${dummyImage} | ${dummyImageExtension} | ${new IsAcceptableCatImageError('Internal Server Error')}
+  `(
+    'should return an IsAcceptableCatImageError because the API will return internalServer error. language: $language',
+    async ({ language, image, imageExtension, expected }) => {
+      const { imageValidator } = useCatImageValidator(language);
+
+      mockServer.use(
+        rest.post(
+          `${appBaseUrl()}${apiList.issueClientCredentialsAccessToken}`,
+          mockTokenEndpoint,
+        ),
+        rest.post(isAcceptableCatImageUrl(), mockInternalServerError),
+      );
+
+      await expect(imageValidator(image, imageExtension)).rejects.toStrictEqual(
+        expected,
+      );
+    },
+  );
+
+  it.each`
+    language  | image         | imageExtension         | expected
+    ${langJa} | ${dummyImage} | ${dummyImageExtension} | ${new IssueAccessTokenError('Internal Server Error')}
+    ${langEn} | ${dummyImage} | ${dummyImageExtension} | ${new IssueAccessTokenError('Internal Server Error')}
+  `(
+    'should return an IssueAccessTokenError because accessToken issuance failed. language: $language',
+    async ({ language, image, imageExtension, expected }) => {
+      const { imageValidator } = useCatImageValidator(language);
+
+      mockServer.use(
+        rest.post(
+          `${appBaseUrl()}${apiList.issueClientCredentialsAccessToken}`,
+          mockInternalServerError,
+        ),
+      );
+
+      await expect(imageValidator(image, imageExtension)).rejects.toStrictEqual(
+        expected,
+      );
+    },
+  );
+});

--- a/src/hooks/__tests__/useCatImageValidator.spec.ts
+++ b/src/hooks/__tests__/useCatImageValidator.spec.ts
@@ -34,7 +34,7 @@ const mockHandlers = [
 const mockServer = setupServer(...mockHandlers);
 
 // eslint-disable-next-line max-lines-per-function, max-statements
-describe('useCatImageValidator isAcceptableCatImage TestCases', () => {
+describe('useCatImageValidator TestCases', () => {
   beforeAll(() => {
     mockServer.listen();
   });

--- a/src/hooks/useCatImageValidator.ts
+++ b/src/hooks/useCatImageValidator.ts
@@ -1,0 +1,95 @@
+import { issueAccessToken } from '../api/fetch/authToken';
+import { isAcceptableCatImage } from '../api/fetch/lgtmImage';
+import { Language } from '../features/language';
+import {
+  AcceptedTypesImageExtension,
+  IsAcceptableCatImageNotAcceptableReason,
+} from '../features/lgtmImage';
+import { createSuccessResult, isFailureResult } from '../features/result';
+import { assertNever } from '../utils/assertNever';
+
+const createNotAcceptableReasons = (
+  notAcceptableReason: IsAcceptableCatImageNotAcceptableReason,
+  language: Language,
+): string[] => {
+  switch (notAcceptableReason) {
+    case 'not an allowed image extension':
+      return language === 'en'
+        ? ['Sorry, only png, jpg, jpeg images can be uploaded.']
+        : ['png, jpg, jpeg の画像のみアップロード出来ます。'];
+    case 'not moderation image':
+      return language === 'en'
+        ? [
+            'Sorry, This image is not available because it shows something inappropriate.',
+          ]
+        : ['この画像は不適切なものが写っているので利用出来ません。'];
+    case 'person face in the image':
+      return language === 'en'
+        ? ["Sorry, please use images that do not show people's faces."]
+        : ['申し訳ありませんが人の顔が写っていない画像をご利用ください。'];
+    case 'not cat image':
+      return language === 'en'
+        ? ['Sorry, but please use images that clearly show the cat.']
+        : ['申し訳ありませんがはっきりと猫が写っている画像をご利用ください。'];
+    case 'an error has occurred':
+      return language === 'en'
+        ? [
+            'An unexpected Error occurred.',
+            'Sorry, please try again after some time has passed.',
+          ]
+        : [
+            '予期せぬエラーが発生しました。',
+            'お手数ですが、しばらく時間が経ってからお試し下さい。',
+          ];
+    default:
+      return assertNever(notAcceptableReason);
+  }
+};
+
+const createCatImageSizeTooLargeErrorMessages = (language: Language) =>
+  language === 'en'
+    ? ['Image size is too large. ', 'Please use images under 4MB.']
+    : [
+        '画像サイズが大きすぎます。',
+        'お手数ですが4MB以下の画像を利用して下さい。',
+      ];
+
+const createImageValidator =
+  (language: Language) =>
+  async (image: string, imageExtension: AcceptedTypesImageExtension) => {
+    const accessToken = await issueAccessToken();
+
+    const isAcceptableCatImageResult = await isAcceptableCatImage({
+      accessToken,
+      image,
+      imageExtension,
+    });
+
+    if (isFailureResult(isAcceptableCatImageResult)) {
+      return createSuccessResult({
+        isAcceptableCatImage: false,
+        notAcceptableReason: createCatImageSizeTooLargeErrorMessages(language),
+      });
+    }
+
+    if (isAcceptableCatImageResult.value.isAcceptableCatImage) {
+      return createSuccessResult({
+        isAcceptableCatImage:
+          isAcceptableCatImageResult.value.isAcceptableCatImage,
+        notAcceptableReason: [],
+      });
+    }
+
+    return createSuccessResult({
+      isAcceptableCatImage:
+        isAcceptableCatImageResult.value.isAcceptableCatImage,
+      notAcceptableReason: createNotAcceptableReasons(
+        isAcceptableCatImageResult.value.notAcceptableReason,
+        language,
+      ),
+    });
+  };
+
+export const useCatImageValidator = (language: Language) => ({
+  imageValidator: createImageValidator(language),
+});

--- a/src/mocks/api/external/recognition/mockIsAcceptableCatImageError.ts
+++ b/src/mocks/api/external/recognition/mockIsAcceptableCatImageError.ts
@@ -1,0 +1,15 @@
+import { ResponseResolver, MockedRequest, restContext } from 'msw';
+
+import { httpStatusCode } from '../../../../constants/httpStatusCode';
+
+export const mockIsAcceptableCatImageError: ResponseResolver<
+  MockedRequest,
+  typeof restContext
+> = (req, res, ctx) =>
+  res(
+    ctx.status(httpStatusCode.ok),
+    ctx.json({
+      isAcceptableCatImage: false,
+      notAcceptableReason: 'an error has occurred',
+    }),
+  );

--- a/src/mocks/api/external/recognition/mockIsAcceptableCatImageNotAllowedImageExtension.ts
+++ b/src/mocks/api/external/recognition/mockIsAcceptableCatImageNotAllowedImageExtension.ts
@@ -1,0 +1,15 @@
+import { ResponseResolver, MockedRequest, restContext } from 'msw';
+
+import { httpStatusCode } from '../../../../constants/httpStatusCode';
+
+export const mockIsAcceptableCatImageNotAllowedImageExtension: ResponseResolver<
+  MockedRequest,
+  typeof restContext
+> = (req, res, ctx) =>
+  res(
+    ctx.status(httpStatusCode.ok),
+    ctx.json({
+      isAcceptableCatImage: false,
+      notAcceptableReason: 'not an allowed image extension',
+    }),
+  );

--- a/src/mocks/api/external/recognition/mockIsAcceptableCatImageNotCatImage.ts
+++ b/src/mocks/api/external/recognition/mockIsAcceptableCatImageNotCatImage.ts
@@ -1,0 +1,15 @@
+import { ResponseResolver, MockedRequest, restContext } from 'msw';
+
+import { httpStatusCode } from '../../../../constants/httpStatusCode';
+
+export const mockIsAcceptableCatImageNotCatImage: ResponseResolver<
+  MockedRequest,
+  typeof restContext
+> = (req, res, ctx) =>
+  res(
+    ctx.status(httpStatusCode.ok),
+    ctx.json({
+      isAcceptableCatImage: false,
+      notAcceptableReason: 'not cat image',
+    }),
+  );

--- a/src/mocks/api/external/recognition/mockIsAcceptableCatImageNotModerationImage.ts
+++ b/src/mocks/api/external/recognition/mockIsAcceptableCatImageNotModerationImage.ts
@@ -1,0 +1,15 @@
+import { ResponseResolver, MockedRequest, restContext } from 'msw';
+
+import { httpStatusCode } from '../../../../constants/httpStatusCode';
+
+export const mockIsAcceptableCatImageNotModerationImage: ResponseResolver<
+  MockedRequest,
+  typeof restContext
+> = (req, res, ctx) =>
+  res(
+    ctx.status(httpStatusCode.ok),
+    ctx.json({
+      isAcceptableCatImage: false,
+      notAcceptableReason: 'not moderation image',
+    }),
+  );

--- a/src/mocks/api/external/recognition/mockIsAcceptableCatImagePersonFaceInImage.ts
+++ b/src/mocks/api/external/recognition/mockIsAcceptableCatImagePersonFaceInImage.ts
@@ -1,0 +1,15 @@
+import { ResponseResolver, MockedRequest, restContext } from 'msw';
+
+import { httpStatusCode } from '../../../../constants/httpStatusCode';
+
+export const mockIsAcceptableCatImagePersonFaceInImage: ResponseResolver<
+  MockedRequest,
+  typeof restContext
+> = (req, res, ctx) =>
+  res(
+    ctx.status(httpStatusCode.ok),
+    ctx.json({
+      isAcceptableCatImage: false,
+      notAcceptableReason: 'person face in the image',
+    }),
+  );

--- a/src/templates/UploadTemplate/UploadTemplate.tsx
+++ b/src/templates/UploadTemplate/UploadTemplate.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 
 import { metaTagList } from '../../features/metaTag';
 import { createSuccessResult } from '../../features/result';
+import { useCatImageValidator } from '../../hooks/useCatImageValidator';
 import { useSaveSettingLanguage } from '../../hooks/useSaveSettingLanguage';
 import { DefaultLayout } from '../../layouts';
 
@@ -25,18 +26,6 @@ export const sleep = (
       resolve();
     }, waitSeconds * millisecond);
   });
-
-const imageValidator = async (
-  image: string,
-  imageExtension: AcceptedTypesImageExtension,
-) => {
-  await sleep();
-
-  return createSuccessResult({
-    isAcceptableCatImage: true,
-    notAcceptableReason: [],
-  });
-};
 
 const imageUploader = async (
   image: string,
@@ -63,6 +52,8 @@ export const UploadTemplate: FC<Props> = ({ language }) => {
   const metaTag = metaTagList(language).upload;
 
   const { saveSettingLanguage } = useSaveSettingLanguage();
+
+  const { imageValidator } = useCatImageValidator(language);
 
   return (
     <DefaultLayout metaTag={metaTag}>


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/lgtm-cat-ui-test/issues/26

# やった事

ねこ画像判定APIをコールする関数 `useCatImageValidator` を実装。

`UploadTemplate` の `imageValidator` から、実装した `useCatImageValidator` を利用するように変更。