### PR TITLE
ロケール周りのリファクタリング

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -8,8 +8,8 @@ module.exports = {
     styledComponents: true,
   },
   i18n: {
-    locales: ['ja-JP', 'en-US'],
-    defaultLocale: 'ja-JP',
+    locales: ['ja', 'en'],
+    defaultLocale: 'ja',
     localeDetection: false,
   },
 };

--- a/src/edge/locale.ts
+++ b/src/edge/locale.ts
@@ -8,7 +8,7 @@ export const mightExtractLocaleFromCookie = (
   const language = req.cookies.get('language');
 
   if (language && language !== 'ja') {
-    return 'en-US';
+    return 'en';
   }
 
   return null;
@@ -18,7 +18,7 @@ export const mightExtractLocaleFromGeo = (req: NextRequest): Locale | null => {
   const country = req.geo?.country?.toLowerCase();
 
   if (country && country !== 'jp') {
-    return 'en-US';
+    return 'en';
   }
 
   return null;
@@ -31,7 +31,7 @@ export const mightExtractLocaleFromAcceptLanguage = (
   const locale = req.headers.get('accept-language')?.split(',')?.[0];
 
   if (locale && locale !== 'ja') {
-    return 'en-US';
+    return 'en';
   }
 
   return null;

--- a/src/features/locale.ts
+++ b/src/features/locale.ts
@@ -1,8 +1,6 @@
-import { assertNever } from '../utils';
+import { languages, type Language } from './language';
 
-import type { Language } from './language';
-
-const locales = ['ja-JP', 'en-US'] as const;
+const locales = languages;
 
 export type Locale = typeof locales[number];
 
@@ -16,14 +14,7 @@ const isLocale = (value: unknown): value is Locale => {
 
 export const convertLocaleToLanguage = (locale: unknown): Language => {
   if (isLocale(locale)) {
-    switch (locale) {
-      case 'ja-JP':
-        return 'ja';
-      case 'en-US':
-        return 'en';
-      default:
-        return assertNever(locale);
-    }
+    return locale;
   }
 
   return 'ja';

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -15,25 +15,25 @@ export const middleware = (req: NextRequest) => {
   const { nextUrl } = req;
 
   const localeExtractedFromCookie = mightExtractLocaleFromCookie(req);
-  if (localeExtractedFromCookie === 'en-US') {
+  if (localeExtractedFromCookie === 'en') {
     nextUrl.pathname = `/${localeExtractedFromCookie}${nextUrl.pathname}`;
 
-    return NextResponse.rewrite(nextUrl);
+    return NextResponse.rewrite(nextUrl.href);
   }
 
   const localeExtractedFromGeo = mightExtractLocaleFromGeo(req);
-  if (localeExtractedFromGeo === 'en-US') {
+  if (localeExtractedFromGeo === 'en') {
     nextUrl.pathname = `/${localeExtractedFromGeo}${nextUrl.pathname}`;
 
-    return NextResponse.rewrite(nextUrl);
+    return NextResponse.rewrite(nextUrl.href);
   }
 
   const localeExtractedFromAcceptLanguage =
     mightExtractLocaleFromAcceptLanguage(req);
-  if (localeExtractedFromAcceptLanguage === 'en-US') {
+  if (localeExtractedFromAcceptLanguage === 'en') {
     nextUrl.pathname = `/${localeExtractedFromAcceptLanguage}${nextUrl.pathname}`;
 
-    return NextResponse.rewrite(nextUrl);
+    return NextResponse.rewrite(nextUrl.href);
   }
 
   return NextResponse.next();

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -18,14 +18,14 @@ export const middleware = (req: NextRequest) => {
   if (localeExtractedFromCookie === 'en') {
     nextUrl.pathname = `/${localeExtractedFromCookie}${nextUrl.pathname}`;
 
-    return NextResponse.rewrite(nextUrl.href);
+    return NextResponse.rewrite(nextUrl);
   }
 
   const localeExtractedFromGeo = mightExtractLocaleFromGeo(req);
   if (localeExtractedFromGeo === 'en') {
     nextUrl.pathname = `/${localeExtractedFromGeo}${nextUrl.pathname}`;
 
-    return NextResponse.rewrite(nextUrl.href);
+    return NextResponse.rewrite(nextUrl);
   }
 
   const localeExtractedFromAcceptLanguage =
@@ -33,7 +33,7 @@ export const middleware = (req: NextRequest) => {
   if (localeExtractedFromAcceptLanguage === 'en') {
     nextUrl.pathname = `/${localeExtractedFromAcceptLanguage}${nextUrl.pathname}`;
 
-    return NextResponse.rewrite(nextUrl.href);
+    return NextResponse.rewrite(nextUrl);
   }
 
   return NextResponse.next();


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/lgtm-cat-ui-test/issues/39

# 内容

ロケールに国コードを含める理由が薄いので、シンプルに [ISO 639-1コード一覧](https://ja.wikipedia.org/wiki/ISO_639-1%E3%82%B3%E3%83%BC%E3%83%89%E4%B8%80%E8%A6%A7) から2桁のコードを利用するように変更した。
