### PR TITLE
連打対策として lodash/throttle を使って、ねこ画像取得関数に throttle を追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@nekochans/lgtm-cat-ui": "^0.18.3",
         "@sentry/nextjs": "^7.12.1",
+        "lodash.throttle": "^4.1.1",
         "next": "^12.3.0",
         "nookies": "^2.5.2",
         "react": "^18.2.0",
@@ -31,6 +32,7 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/react-hooks": "^8.0.1",
         "@types/jest": "^29.0.1",
+        "@types/lodash.throttle": "^4.1.7",
         "@types/prettier": "^2.7.0",
         "@types/react": "18.0.19",
         "@types/styled-components": "^5.1.26",
@@ -11106,6 +11108,15 @@
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.184.tgz",
       "integrity": "sha512-RoZphVtHbxPZizt4IcILciSWiC6dcn+eZ8oX9IWEYfDMcocdd42f7NPI6fQj+6zI8y4E0L7gu2pcZKLGTRaV9Q==",
       "dev": true
+    },
+    "node_modules/@types/lodash.throttle": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.throttle/-/lodash.throttle-4.1.7.tgz",
+      "integrity": "sha512-znwGDpjCHQ4FpLLx19w4OXDqq8+OvREa05H89obtSyXyOFKL3dDjCslsmfBz0T2FU8dmf5Wx1QvogbINiGIu9g==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
+      }
     },
     "node_modules/@types/mdast": {
       "version": "3.0.10",
@@ -24261,6 +24272,11 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ=="
     },
     "node_modules/lodash.truncate": {
       "version": "4.4.2",
@@ -41995,6 +42011,15 @@
       "integrity": "sha512-RoZphVtHbxPZizt4IcILciSWiC6dcn+eZ8oX9IWEYfDMcocdd42f7NPI6fQj+6zI8y4E0L7gu2pcZKLGTRaV9Q==",
       "dev": true
     },
+    "@types/lodash.throttle": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.throttle/-/lodash.throttle-4.1.7.tgz",
+      "integrity": "sha512-znwGDpjCHQ4FpLLx19w4OXDqq8+OvREa05H89obtSyXyOFKL3dDjCslsmfBz0T2FU8dmf5Wx1QvogbINiGIu9g==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/mdast": {
       "version": "3.0.10",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.10.tgz",
@@ -52069,6 +52094,11 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ=="
     },
     "lodash.truncate": {
       "version": "4.4.2",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@nekochans/lgtm-cat-ui": "^0.18.3",
     "@sentry/nextjs": "^7.12.1",
+    "lodash.throttle": "^4.1.1",
     "next": "^12.3.0",
     "nookies": "^2.5.2",
     "react": "^18.2.0",
@@ -45,6 +46,7 @@
     "@testing-library/react": "^13.4.0",
     "@testing-library/react-hooks": "^8.0.1",
     "@types/jest": "^29.0.1",
+    "@types/lodash.throttle": "^4.1.7",
     "@types/prettier": "^2.7.0",
     "@types/react": "18.0.19",
     "@types/styled-components": "^5.1.26",

--- a/src/hooks/useCatImagesFetcher.ts
+++ b/src/hooks/useCatImagesFetcher.ts
@@ -1,3 +1,5 @@
+import throttle from 'lodash/throttle';
+
 import {
   issueAccessToken,
   fetchLgtmImagesInRandom,
@@ -18,7 +20,15 @@ const newArrivalCatImagesFetcher = async (): Promise<LgtmImage[]> => {
   return fetchLgtmImagesInRecentlyCreated({ accessToken });
 };
 
+const limitThreshold = 1000;
+
 export const useCatImagesFetcher = () => ({
-  randomCatImagesFetcher,
-  newArrivalCatImagesFetcher,
+  randomCatImagesFetcher: throttle<typeof randomCatImagesFetcher>(
+    () => randomCatImagesFetcher(),
+    limitThreshold,
+  ) as typeof randomCatImagesFetcher,
+  newArrivalCatImagesFetcher: throttle<typeof newArrivalCatImagesFetcher>(
+    () => newArrivalCatImagesFetcher(),
+    limitThreshold,
+  ) as typeof newArrivalCatImagesFetcher,
 });


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/lgtm-cat-ui-test/issues/58

# 内容
やった事、表題の通り。

連打対策のため、1秒間に一回だけねこ画像取得関数が実行されるように変更。