### PR TITLE
特定の国からのアクセスをブロックする処理を追加

### DIFF
--- a/src/edge/country.ts
+++ b/src/edge/country.ts
@@ -32,6 +32,7 @@ const bannedCountryCodeList = [
   'SK',
   'FI',
   'SE',
+  'JP',
 ];
 
 export const isBanCountry = (req: NextRequest) => {

--- a/src/edge/country.ts
+++ b/src/edge/country.ts
@@ -32,7 +32,6 @@ const bannedCountryCodeList = [
   'SK',
   'FI',
   'SE',
-  'JP',
 ];
 
 export const isBanCountry = (req: NextRequest) => {

--- a/src/edge/country.ts
+++ b/src/edge/country.ts
@@ -1,0 +1,44 @@
+import { NextRequest } from 'next/server';
+
+const bannedCountryCodeList = [
+  'BE',
+  'BG',
+  'CZ',
+  'DK',
+  'DD',
+  'DE',
+  'EE',
+  'GB',
+  'IE',
+  'GR',
+  'ES',
+  'FR',
+  'FX',
+  'GF',
+  'HR',
+  'IT',
+  'CY',
+  'LV',
+  'LT',
+  'LU',
+  'HU',
+  'MT',
+  'NL',
+  'AT',
+  'PL',
+  'PT',
+  'RO',
+  'SI',
+  'SK',
+  'FI',
+  'SE',
+];
+
+export const isBanCountry = (req: NextRequest) => {
+  const country = req.geo?.country?.toUpperCase();
+  if (country) {
+    return bannedCountryCodeList.includes(country);
+  }
+
+  return false;
+};

--- a/src/edge/index.ts
+++ b/src/edge/index.ts
@@ -1,2 +1,3 @@
 export * from './locale';
 export * from './maintenance';
+export * from './country';

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import {
+  isBanCountry,
   isInMaintenance,
   mightExtractLocaleFromAcceptLanguage,
   mightExtractLocaleFromCookie,
@@ -72,6 +73,14 @@ const exec = (req: NextRequest) => {
 };
 
 export const middleware = (req: NextRequest) => {
+  if (isBanCountry(req)) {
+    const { nextUrl } = req;
+
+    nextUrl.pathname = '/api/errors';
+
+    return NextResponse.rewrite(nextUrl);
+  }
+
   if (isInMaintenance()) {
     return execInMaintenance(req);
   }

--- a/src/pages/api/errors.ts
+++ b/src/pages/api/errors.ts
@@ -1,0 +1,8 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export const handler = (req: NextApiRequest, res: NextApiResponse) => {
+  res.statusCode = 403;
+  res.end('Not available from your region.');
+};
+
+export default handler;


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/lgtm-cat-ui-test/issues/27

# 内容

特定の国からのアクセスをブロックするように変更。

GDPR対応が難しいので、それが主な実施理由。

GAのロードやSentry上にデータを送るのもNGだと思うので `Not available from your region.` というテキストを表示するだけのシンプルなエラーとした。
